### PR TITLE
hambt association logs

### DIFF
--- a/lib/recorder/tape.rb
+++ b/lib/recorder/tape.rb
@@ -108,31 +108,34 @@ module Recorder
     end
 
 
-    # For use this method you need add to your model next config:
-    # recorder associations_hambt: [
+    # For use this method you need add to your model next params:
+    # associations_hambt: [
     #   {
     #     class: :lots,                        # -- name associations
-    #     check_change: :lots_changed?,        # -- method who return true/false if habtm changes
-    #     old_collection: :old_lots_collection # -- old collection
+    #     check_change: lots_changed?,         # -- method who return true/false if habtm changes
+    #     old_collection: old_lots_collection  # -- old collection
     #   }
     # ]
     #
     #
-    # Example
-    # Method rewrites assignment habtm ids
+    # # Example
+    # # Method rewrites assignment habtm ids
     #
     # def lot_ids=(ids)
     #   @lots_changed = ids != lot_ids                   #  return true/nil
     #   @old_lots_collection = lot_ids if @lots_changed  #  remembers the old collection, may be nil
-
     #   super(ids)
     # end
     #
-    #  return true/false if habtm changes
+    # # return true/false if habtm changes
     # def lots_changed?
     #   @lots_changed || false
     # end
-    # And add attr_reade to @old_lots_collection
+    #
+    #
+    # def old_lots_collection
+    #   @old_lots_collection
+    # end
 
     def parse_associations_attributes_for_habtm(event)
       self.item.recorder_options[:associations_hambt].inject({}) do |hash, association|

--- a/lib/recorder/tape.rb
+++ b/lib/recorder/tape.rb
@@ -135,18 +135,18 @@ module Recorder
     # And add attr_reade to @old_lots_collection
 
     def parse_associations_attributes_for_habtm(event)
-      object.item.recorder_options[:associations_hambt].inject({}) do |hash, association|
-        reflection = object.item.class.reflect_on_association(association[:class])
+      self.item.recorder_options[:associations_hambt].inject({}) do |hash, association|
+        raise ArgumentError if association[:class].nil? && association[:check_change].nil? && association[:old_collection]
+        reflection = self.item.class.reflect_on_association(association[:class])
         if reflection.present?
           if reflection.collection?
-            if object.item.send(association[:check_change])
-              # changes = Recorder::Tape.new(object).changes_for(:update)
-              # hash[reflection.name]
+            if self.item.send(association[:check_change])
+              changes = [self.item.send(association[:old_collection]), self.item.lot_ids]
+              hash["#{association[:class]}_id".to_sym] = changes
             end
-          else
-
           end
         end
+        hash
       end
     end
   end

--- a/lib/recorder/version.rb
+++ b/lib/recorder/version.rb
@@ -3,7 +3,7 @@ module Recorder
   module VERSION
     MAJOR = 0
     MINOR = 1
-    PATCH = 24
+    PATCH = 25
     PRE = nil
 
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join(".").freeze


### PR DESCRIPTION
Add habtm associations.

In model you need write something like this (code for example):
```
class Deal::Quotation < ApplicationRecord
  
  include ::Recorder::Observer

  has_and_belongs_to_many :lots

  recorder async: false, associations_hambt: [
    {
      class: :lots,
      check_change: lots_changed?,
      old_collection: old_lots_collection
    }
  ]

 def lot_ids=(ids)
    @lots_changed = ids != lot_ids
    @old_lots_collection = lot_ids if @lots_changed

    super(ids)
  end

  def lots_changed?
    @lots_changed || false
  end

  def old_lots_collection
    @old_lots_collection
  end
end
```

And next, in Recorder::Revision changes you can see next string: 
` data: {"associations_habtm"=>{"lots_id"=>[[1, 2], [1]]}},`

May be it's good?) 