### PR TITLE
Added support for Config's new :only feature

### DIFF
--- a/lib/recorder/config.rb
+++ b/lib/recorder/config.rb
@@ -4,7 +4,9 @@ module Recorder
   # Global configuration options
   class Config
     include Singleton
-    attr_accessor :sidekiq_options, :ignore
+    attr_accessor :sidekiq_options
+    attr_reader :ignore
+    attr_reader :only
 
     def initialize
       # Variables which affect all threads, whose access is synchronized.
@@ -18,10 +20,15 @@ module Recorder
       }
 
       @ignore = Array.new
+      @only = Array.new
     end
 
     def ignore=(value)
       @ignore = Array.wrap(value).map(&:to_sym)
+    end
+
+    def only=(value)
+      @only = Array.wrap(value).map(&:to_sym)
     end
 
     # Indicates whether Recorder is on or off. Default: true.

--- a/lib/recorder/tape.rb
+++ b/lib/recorder/tape.rb
@@ -73,12 +73,24 @@ module Recorder
     end
 
     def sanitize_attributes(attributes = {})
-      if self.item.respond_to?(:recorder_options) && self.item.recorder_options[:ignore].present?
-        ignore = Array.wrap(self.item.recorder_options[:ignore]).map(&:to_sym)
-        attributes.symbolize_keys.except(*ignore)
+      attributes = attributes.dup.symbolize_keys
+
+      if item.respond_to?(:recorder_options)
+        if item.recorder_options[:ignore].present?
+          ignore = Array.wrap(item.recorder_options[:ignore]).map(&:to_sym)
+          attributes = attributes.except(*ignore)
+        end
+
+        if item.recorder_options[:only].present?
+          only = Array.wrap(item.recorder_options[:only]).map(&:to_sym)
+          attributes = attributes.slice(*only)
+        end
+
       else
-        attributes.symbolize_keys.except(*Recorder.config.ignore)
+        attributes = attributes.except(*Recorder.config.ignore)
+        attributes = attributes.slice(*Recorder.config.only) unless Recorder.config.only.empty?
       end
+        attributes
     end
 
     def parse_associations_attributes(event)

--- a/spec/recorder/config_spec.rb
+++ b/spec/recorder/config_spec.rb
@@ -22,7 +22,7 @@ module Recorder
 
     describe '#ignore=' do
       it 'accepts configuration' do
-        options = [:created_at, :updated_at]
+        options = %i[created_at updated_at]
 
         described_class.instance.ignore = options
 
@@ -36,6 +36,31 @@ module Recorder
 
         expect(described_class.instance.ignore).to be_an_instance_of(Array)
         expect(described_class.instance.ignore).to eq(Array.wrap(options))
+      end
+    end
+
+    describe '#only' do
+      it 'defaults to empty `Array`' do
+        expect(described_class.instance.only).to eq([])
+      end
+    end
+
+    describe '#only=' do
+      it 'accepts configuration' do
+        options = %i[created_at updated_at]
+
+        described_class.instance.only = options
+
+        expect(described_class.instance.only).to eq(options)
+      end
+
+      it 'wraps argument with `Array`' do
+        options = :created_at
+
+        described_class.instance.only = options
+
+        expect(described_class.instance.only).to be_an_instance_of(Array)
+        expect(described_class.instance.only).to eq(Array.wrap(options))
       end
     end
 


### PR DESCRIPTION
Now instead of explicitly list ignored attributes on model one can whitelist
them with `only` option.